### PR TITLE
updateVariation no longer has a side effect

### DIFF
--- a/lib/OptimizelyClient.js
+++ b/lib/OptimizelyClient.js
@@ -392,21 +392,21 @@ OptimizelyClient.prototype.getVariation = function(options) {
  *}
  */
 OptimizelyClient.prototype.updateVariation = function(options) {
+  var optionsToUpdate = {};
   options = options || {};
-  options.id = options.id || "";
-  options.description = options.description || "";
-  options.js_component = options.js_component || "";
   if (!options.id) throw new Error(
     "Required: options.id");
+  optionsToUpdate.id = options.id || "";
+  optionsToUpdate.description = options.description || "";
+  optionsToUpdate.js_component = options.js_component || "";
   var theUrl = this.baseUrl + 'variations/' + options.id;
-  delete options.id;
   return rest.putAsync(theUrl, {
     method: 'put',
     headers: {
       'Token': this.apiToken,
       'Content-Type': 'application/json'
     },
-    data: JSON.stringify(options)
+    data: JSON.stringify(optionsToUpdate)
   })
 }
 module.exports = OptimizelyClient;


### PR DESCRIPTION
OptimizelyClient.updateVariation had an unwanted side effect of deleting ID off of options when executing. Since objects are passed by reference, this means that the ID was being removed from options outside of the client as well. This makes it so there is no side effect from using updateVariation.
